### PR TITLE
 Added support for JSON number values

### DIFF
--- a/jwt.sql
+++ b/jwt.sql
@@ -17,7 +17,7 @@ begin
                         (
                             select ',"'
                                     + coalesce(b.c.value('local-name(.)', 'nvarchar(max)'), '')
-									+ '":'
+                                    + '":'
                                     + IIF(ISNUMERIC(b.c.value('text()[1]','nvarchar(max)')) = 1, '', '"')
                                     + b.c.value('text()[1]','nvarchar(max)')
                                     + IIF(ISNUMERIC(b.c.value('text()[1]','nvarchar(max)')) = 1, '', '"')

--- a/jwt.sql
+++ b/jwt.sql
@@ -17,9 +17,9 @@ begin
                         (
                             select ',"'
                                     + coalesce(b.c.value('local-name(.)', 'nvarchar(max)'), '')
-                                    + '":"'
+                                    + IIF(ISNUMERIC(b.c.value('text()[1]','nvarchar(max)')) = 1, '', '"')
                                     + b.c.value('text()[1]','nvarchar(max)')
-                                    + '"'
+                                    + IIF(ISNUMERIC(b.c.value('text()[1]','nvarchar(max)')) = 1, '', '"')
 
                             from    x.a.nodes('*') b(c)
 

--- a/jwt.sql
+++ b/jwt.sql
@@ -17,6 +17,7 @@ begin
                         (
                             select ',"'
                                     + coalesce(b.c.value('local-name(.)', 'nvarchar(max)'), '')
+									+ '":'
                                     + IIF(ISNUMERIC(b.c.value('text()[1]','nvarchar(max)')) = 1, '', '"')
                                     + b.c.value('text()[1]','nvarchar(max)')
                                     + IIF(ISNUMERIC(b.c.value('text()[1]','nvarchar(max)')) = 1, '', '"')


### PR DESCRIPTION
 Added support for JSON number values, such as iat, when converting XML->JSON.

Known issues: As IsNumeric() seems to validate numbers inside a string very liberally so that floats '123.567' and formatted decimals '123.9,00' are detected as numbers, while they are not valid in JSON. Could be fixed by switching the test function to something more strict?