### PR TITLE
Update HMAC Implementation

### DIFF
--- a/jwt.sql
+++ b/jwt.sql
@@ -46,55 +46,97 @@ go
 ---------------------
 -- HMAC Encryption --
 ---------------------
-if object_id('dbo.HMAC') is not null
-  drop function dbo.HMAC
-go
+/*
+	Copyright © 2012 Ryan Malayter. All Rights Reserved.
 
-create function dbo.HMAC(
- @key   varchar(max),
- @message varchar(max),
- @method  varchar(20)
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are
+	met:
+
+	1. Redistributions of source code must retain the above copyright
+	notice, this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	3. The name of the author may not be used to endorse or promote products
+	derived from this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY Ryan Malayter "AS IS" AND ANY EXPRESS OR
+	IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+	SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+	STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* 
+	This function only takes VARBINARY parameters instead of VARCHAR
+	to prevent problems with implicit conversion from NVARCHAR to VARCHAR
+	which result in incorrect hashes for inputs including non-ASCII characters.
+	Always cast @key and @data parameters to VARBINARY when using this function.
+	Tested against HMAC vectors for MD5 and SHA1 from RFC 2202
+*/
+
+/*
+	List of secure hash algorithms (parameter @algo) supported by MSSQL
+	version. This is what is passed to the HASHBYTES system function.
+	Omit insecure hash algorithms such as MD2 through MD5
+	2005-2008R2: SHA1
+	2012-2016: SHA1 | SHA2_256 | SHA2_512
+*/
+create or alter function dbo.hmac (
+	@key	varbinary(max),
+	@data	varbinary(MAX),
+	@algo	varchar(20)
 )
-returns varchar(max)
+returns varbinary(64)
 as
 begin
+	declare @ipad	bigint
+	declare @opad	bigint
+	declare @i		varbinary(64)
+	declare @o		varbinary(64)
+	declare @pos	integer
 
- declare @i_key_pad varchar(max)  = '';
- declare @o_key_pad varchar(max)  = '';
- declare @position  int   = 1;
+	-- SQL 2005 only allows XOR operations on integer types, so use bigint and iterate 8 times
+	set @ipad = cast(0x3636363636363636 as bigint) -- constants from HMAC definition
+	set @opad = cast(0x5C5C5C5C5C5C5C5C as bigint)
 
- -- hash key if longer than 16 characters
- if(len(@key) > 64) set @key = hashbytes(@method, @key);
+	if len(@key) > 64 -- if the key is greater than 512 bits we hash it first per HMAC definition
+		set @key = cast(hashbytes(@algo, @key) as binary (64))
+	else
+		set @key = cast(@key as binary (64)) -- otherwise pad it out to 512 bits with zeros
 
- -- splice ipad & opod with key
- while @position <= len(@key)
- begin
-  set @i_key_pad = @i_key_pad + char(ascii(substring(@key, @position, 1)) ^ 54);
-  set @o_key_pad = @o_key_pad + char(ascii(substring(@key, @position, 1)) ^ 92);
-  set @position = @position + 1;
- end
+	set @pos = 1
+	set @i = cast('' AS varbinary(64)) -- initialize as empty binary value
 
- --pad i_key_pad & o_key_pad
- set @i_key_pad = left(@i_key_pad + replicate('6',64),64);
- set @o_key_pad = left(@o_key_pad + replicate('\',64),64);
+	while @pos <= 57
+	begin
+		set @i = @i + cast((substring(@key, @pos, 8) ^ @ipad) as varbinary(64))
+		set @pos = @pos + 8
+	end
 
- return hashbytes
-  (
-   @method,
-   convert(varbinary(max), @o_key_pad)
-    + hashbytes
-    (
-     @method,
-     @i_key_pad + @message
-    )
-  );
+	set @pos = 1
+	set @o = cast('' as varbinary(64)) -- initialize as empty binary value
 
-end;
+	while @pos <= 57
+	begin
+		set @o = @o + cast((substring(@key, @pos, 8) ^ @opad) as varbinary(64))
+		set @pos = @pos + 8
+	end
 
+	return hashbytes(@algo, @o + hashbytes(@algo, @i + @data))
+end
 go
 
 grant execute on dbo.HMAC to public
-
 go
 
 ---------------------
@@ -123,47 +165,63 @@ begin
 
   return @base64string
 end
-
 go
 
 grant execute on dbo.Base64 to public
-
 go
 
 -----------------------------
 -- JSON Web Token Creation --
 -----------------------------
-if object_id('dbo.JWT_Encode') is not null
-  drop function dbo.JWT_Encode
-go
-
-create function dbo.JWT_Encode(@header varchar(max), @payload varchar(max), @secret varchar(max))
+create or alter function dbo.JWT_Encode(
+	@json_header	varchar(max),
+	@json_payload	varchar(max),
+	@secret			varchar(max)
+)
 returns varchar(max)
 as
 begin
 
-  declare @h varchar(max),
-          @d varchar(max),
-          @sig varchar(max)
+	declare @header		varchar(max),
+			@data		varchar(max),
+			@signature	varchar(max);
 
-  select @h = dbo.Base64(convert(varbinary(max), @header), 1)
+	-- Base64 encode json header
+	select @header = dbo.Base64(convert(varbinary(max), @json_header), 1);
 
-  select @d = dbo.Base64(convert(varbinary(max), @payload), 1)
+	-- Base64 encode json payload
+	select @data = dbo.Base64(convert(varbinary(max), @json_payload), 1);
 
-  select @sig = dbo.Base64(convert(varbinary(max), dbo.HMAC(@secret, @h + '.' + @d, 'SHA2_256')), 1)
+	-- Generate signature
+	select	@signature = dbo.HMAC(convert(varbinary(max), @secret), convert(varbinary(max), @header + '.' + @data), 'SHA2_256');
 
-  return @h + '.' + @d + '.' + @sig
+	-- Base64 encode signature
+	select	@signature = dbo.Base64(convert(varbinary(max), @signature), 1);
+
+	return @header + '.' + @data + '.' + @signature;
 end
-
 go
 
 grant execute on dbo.JWT_Encode to public
-
 go
 
 -------------------
 -- Example Usage --
 -------------------
-select dbo.JWT_Encode(dbo.XmlToJson((select 'HS256' alg, 'JWT' typ for xml path, root)),
-                      dbo.XmlToJson((select 'chris' name, 'true' admin for xml path, root)),
-                      'secret')
+select	dbo.JWT_Encode(
+			dbo.XmlToJson((select 'HS256' alg, 'JWT' typ for xml path, root)),
+			dbo.XmlToJson((select 'chris' name, 'true' admin for xml path, root)),
+			'secret'
+		)
+
+select	dbo.JWT_Encode(
+			(select 'HS256' alg, 'JWT' typ for json path, without_array_wrapper),
+			(select 'brian' name, 'true' admin for json path, without_array_wrapper),
+			'secret'
+		)
+
+select	dbo.JWT_Encode(
+			'{"alg":"HS256","typ":"JWT"}',
+			'{"name":"brian","admin":"true"}',
+			'secret'
+		)


### PR DESCRIPTION
- HMAC implementation fails for certain inputs, causing jwts to fail when decoded, raising `Signature verification raised`
- I tested updated HMAC function by generating a list of tokens and then decoding them, for both implementations
- updated HMAC implementation fixes the failures