### PR TITLE
Updating Base64 to use a JSON approach to generate Base64 strings

### DIFF
--- a/jwt.sql
+++ b/jwt.sql
@@ -155,7 +155,15 @@ as
 begin
   declare @base64string varchar(max)
 
-  select @base64string = cast('' as xml).value('xs:base64Binary(sql:variable(''@data''))', 'varchar(max)')
+   -- When converting a table to json, binary data in the table is converted to a BASE64 String
+  select @base64string = col
+  from openjson(
+    (
+      select col
+      from (select @data col) T
+      for json auto
+    )
+  ) with(col varchar(max))
 
   if @url_safe = 1
   begin


### PR DESCRIPTION
This change addresses an error that occurs from the use of XML while calculating Base64 strings within JWT_Encode when `ansi_warnings` set to `off` in the database.

The original error message:

`SELECT failed because the following SET options have incorrect settings: 'ANSI_WARNINGS'. Verify that SET options are correct for use with indexed views and/or indexes on computed columns and/or filtered indexes and/or query notifications and/or XML data type methods and/or spatial index operations.`

Updating Base64 to use a JSON approach to generate Base64 strings avoids this issue whether ansi_warnings are enabled or disabled.
